### PR TITLE
Add line break and change div to span in validtion error display

### DIFF
--- a/includes/register.php
+++ b/includes/register.php
@@ -80,11 +80,11 @@ function register_plugin($plugin) {
       $fail_update_status = get_transient( $transient_key );
       if (empty($fail_update_status)) return;
 
-      ?><div style="color: #d63638; font-weight: bold;">
+      ?><br /><span style="color: #d63638; font-weight: bold;">
         ⚠️ Update failed: <?php
           echo esc_html($fail_update_status);
         ?>
-      </div><?php
+      </span><?php
     });
   }
 


### PR DESCRIPTION
Hello brother!

I added <br /> and changed div to span since it is displaying like this:
![Screenshot 2025-04-25 215024](https://github.com/user-attachments/assets/840706dc-734d-4beb-af25-878a6b24c35d)

This changed fixed that and it now looks like this:
![Screenshot 2025-04-25 220105](https://github.com/user-attachments/assets/07c9fba9-61ac-4ed2-8801-03ac9457eff9)

You can delete this branch after merging.

Thanks bro!