### PR TITLE
License notice: Support multiple plugins

### DIFF
--- a/includes/register.php
+++ b/includes/register.php
@@ -99,10 +99,10 @@ function register_plugin($plugin) {
         ?>
       </span><?php
     });
-  }
 
-  // Set up plugin notices
-  require_once __DIR__ . '/license/notice.php';
+    // Set up plugin notices
+    require __DIR__ . '/license/notice.php';
+  }
 }
 
 function register_theme($theme) {

--- a/tests/phpunit/cloud.php
+++ b/tests/phpunit/cloud.php
@@ -84,4 +84,37 @@ class Cloud_TestCase extends \WP_UnitTestCase {
     $this->assertTrue(true);
   }
 
+  function test_license_notice_hook() {
+
+    global $wp_filter;
+
+    $first_plugin = $this->register_with_framework([
+      'name'     => 'first-plugin-name',
+      'cloud_id' => 123
+    ]);
+
+    $second_plugin = $this->register_with_framework([
+      'name'     => 'second-plugin-name',
+      'cloud_id' => 124
+    ]);
+
+    $third_plugin = $this->register_with_framework([
+      'name' => 'third-plugin-name'
+    ]);
+
+    updater\register_plugin($first_plugin);
+    updater\register_plugin($second_plugin);
+    updater\register_plugin($third_plugin);
+
+    foreach ([ $first_plugin, $second_plugin ] as $plugin ) {
+
+      $action_name = "after_plugin_row_{$plugin->name}/{$plugin->name}.php";
+      $action_count = count($wp_filter[$action_name]->callbacks);
+
+      $this->assertEquals(1, $action_count);
+    }
+
+    $action_name = "after_plugin_row_{$third_plugin->name}/{$third_plugin->name}.php";
+    $this->assertEquals(false, isset($wp_filter[$action_name]));
+  }
 }

--- a/tests/plugin.php
+++ b/tests/plugin.php
@@ -10,7 +10,7 @@ use tangible\updater;
 add_action('plugins_loaded', function() {
 
   $plugin = framework\register_plugin([
-    'name' => 'test-plugin',
+    'name'           => 'test-plugin',
     'title'          => 'Test Plugin',
     'setting_prefix' => 'test_plugin',
 


### PR DESCRIPTION
Hi @eliot-akira!

I noticed a small issue recently while working on fields, where this warning started showing up:
>Warning: Undefined property: stdClass::$setting_prefix in /var/www/html/blocks/wp-content/plugins/updater/vendor/tangible/framework/plugin/settings/index.php on line 9

This issue happens because we attempt to get the license key [here](https://github.com/TangibleInc/updater/blob/6573889f0b2416531adf95acd1d79969007be56d/includes/license/notice.php#L10), and as fields does not have a settings prefix set it throws this warning

As a fix, I moved `require_once __DIR__ . '/notice.php'` inside [this condition](https://github.com/TangibleInc/updater/blob/6573889f0b2416531adf95acd1d79969007be56d/includes/register.php#L71) because the logic from this file seems to only be needed for plugins that will rely on the cloud

I also changed `require_once` to `require`, as otherwise the notice is only being registered for the first plugin that calls `updater\register_plugin()`